### PR TITLE
Mejora reloj

### DIFF
--- a/src/components/timeRemaining/TimeRemaining.tsx
+++ b/src/components/timeRemaining/TimeRemaining.tsx
@@ -7,28 +7,69 @@ export interface TimeRemainingProps {
    * Date of completion
    */
   dueTime: Date;
+
+  /**
+   * Display with only one time unit? (8h instead of 8h 20min)
+   */
+  simpleDisplay?: boolean;
 }
 
-export const TimeRemaining = (props: TimeRemainingProps) => {
+const getMsRemaining = (dueTime: Date) => {};
+
+const getTimeRemaining = (dueTime: Date) => {
   const msOnADay = 1000 * 60 * 60 * 24;
   const msOnAnHour = 1000 * 60 * 60;
-  
-  const msRemaining = props.dueTime.getTime() - new Date().getTime();
-  const daysRemaining = Math.floor(msRemaining / msOnADay);
-  const hoursRemaining = Math.floor(
-    (msRemaining - daysRemaining * msOnADay) / msOnAnHour
+  const msOnAnMinute = 1000 * 60;
+
+  const totalMilliseconds = dueTime.getTime() - new Date().getTime();
+  const days: number = +Math.floor(totalMilliseconds / msOnADay);
+  const hours: number = +Math.floor(
+    (totalMilliseconds - days * msOnADay) / msOnAnHour
+  );
+  const minutes: number = +Math.floor(
+    totalMilliseconds - (days * msOnADay + hours * msOnAnHour) / msOnAnMinute
   );
 
+  return [
+    [days, 'd'],
+    [hours, 'h'],
+    [minutes, 'min'],
+  ];
+};
+
+const getTimeText = (props: TimeRemainingProps) => {
+  const totalMilliseconds = props.dueTime.getTime() - new Date().getTime();
+  let result;
+
+  if (totalMilliseconds > 0) {
+    result = '';
+    for (const [value, unitType] of getTimeRemaining(props.dueTime)) {
+      if (value > 0) {
+        result += `${value}${unitType} `;
+        if (props.simpleDisplay) {
+          break;
+        }
+      }
+    }
+
+    if(result =''){
+      
+    }
+  } else {
+    result = (
+      <span style={{ color: 'red', fontWeight: 'bold', fontSize: '0.75em' }}>
+        EXPIRADO
+      </span>
+    );
+  }
+  return result;
+};
+
+export const TimeRemaining = (props: TimeRemainingProps) => {
   return (
     <div className="time-remaining">
       <TbClockFilled className="time-remaining__icon" size={24}></TbClockFilled>
-      {msRemaining > 0 ? (
-        `${daysRemaining}d ${hoursRemaining}h`
-      ) : (
-        <span style={{ color: 'red', fontWeight: 'bold', fontSize: '0.75em' }}>
-          EXPIRADO
-        </span>
-      )}
+      {getTimeText(props)}
     </div>
   );
 };

--- a/src/components/timeRemaining/TimeRemaining.tsx
+++ b/src/components/timeRemaining/TimeRemaining.tsx
@@ -14,8 +14,6 @@ export interface TimeRemainingProps {
   simpleDisplay?: boolean;
 }
 
-const getMsRemaining = (dueTime: Date) => {};
-
 const getTimeRemaining = (dueTime: Date) => {
   const msOnADay = 1000 * 60 * 60 * 24;
   const msOnAnHour = 1000 * 60 * 60;
@@ -27,7 +25,7 @@ const getTimeRemaining = (dueTime: Date) => {
     (totalMilliseconds - days * msOnADay) / msOnAnHour
   );
   const minutes: number = +Math.floor(
-    totalMilliseconds - (days * msOnADay + hours * msOnAnHour) / msOnAnMinute
+    (totalMilliseconds - (days * msOnADay + hours * msOnAnHour)) / msOnAnMinute
   );
 
   return [
@@ -38,31 +36,26 @@ const getTimeRemaining = (dueTime: Date) => {
 };
 
 const getTimeText = (props: TimeRemainingProps) => {
-  const totalMilliseconds = props.dueTime.getTime() - new Date().getTime();
-  let result;
+  let result = '';
 
-  if (totalMilliseconds > 0) {
-    result = '';
-    for (const [value, unitType] of getTimeRemaining(props.dueTime)) {
-      if (value > 0) {
-        result += `${value}${unitType} `;
-        if (props.simpleDisplay) {
-          break;
-        }
+  for (const [value, unitType] of getTimeRemaining(props.dueTime)) {
+    if (value > 0) {
+      result += `${value}${unitType} `;
+      if (props.simpleDisplay == true) {
+        break;
       }
     }
+  }
 
-    if(result =''){
-      
-    }
-  } else {
-    result = (
+  if ((result == '')) {
+    return (
       <span style={{ color: 'red', fontWeight: 'bold', fontSize: '0.75em' }}>
         EXPIRADO
       </span>
     );
+  } else {
+    return result;
   }
-  return result;
 };
 
 export const TimeRemaining = (props: TimeRemainingProps) => {

--- a/src/components/timeRemaining/TimeRemaining.tsx
+++ b/src/components/timeRemaining/TimeRemaining.tsx
@@ -14,12 +14,16 @@ export interface TimeRemainingProps {
   simpleDisplay?: boolean;
 }
 
-const getTimeRemaining = (dueTime: Date) => {
+const getMsRemaining = (dueTime: Date) => {
+  return dueTime.getTime() - new Date().getTime();
+};
+
+const getFormattedTimeReamining = (dueTime: Date) => {
   const msOnADay = 1000 * 60 * 60 * 24;
   const msOnAnHour = 1000 * 60 * 60;
   const msOnAnMinute = 1000 * 60;
 
-  const totalMilliseconds = dueTime.getTime() - new Date().getTime();
+  const totalMilliseconds = getMsRemaining(dueTime);
   const days: number = +Math.floor(totalMilliseconds / msOnADay);
   const hours: number = +Math.floor(
     (totalMilliseconds - days * msOnADay) / msOnAnHour
@@ -38,23 +42,23 @@ const getTimeRemaining = (dueTime: Date) => {
 const getTimeText = (props: TimeRemainingProps) => {
   let result = '';
 
-  for (const [value, unitType] of getTimeRemaining(props.dueTime)) {
-    if (value > 0) {
-      result += `${value}${unitType} `;
-      if (props.simpleDisplay == true) {
-        break;
+  if (getMsRemaining(props.dueTime) > 0) {
+    for (const [value, unitType] of getFormattedTimeReamining(props.dueTime)) {
+      if (value > 0) {
+        result += `${value}${unitType} `;
+        if (props.simpleDisplay) {
+          break;
+        }
       }
     }
-  }
 
-  if ((result == '')) {
+    return result;
+  } else {
     return (
       <span style={{ color: 'red', fontWeight: 'bold', fontSize: '0.75em' }}>
         EXPIRADO
       </span>
     );
-  } else {
-    return result;
   }
 };
 

--- a/src/components/timeRemaining/TimeRemaining.tsx
+++ b/src/components/timeRemaining/TimeRemaining.tsx
@@ -19,17 +19,17 @@ const getMsRemaining = (dueTime: Date) => {
 };
 
 const getFormattedTimeReamining = (dueTime: Date) => {
-  const msOnADay = 1000 * 60 * 60 * 24;
-  const msOnAnHour = 1000 * 60 * 60;
-  const msOnAnMinute = 1000 * 60;
+  const MS_PER_DAY = 1000 * 60 * 60 * 24;
+  const MS_PER_HOUR = 1000 * 60 * 60;
+  const MS_PER_MINUTE = 1000 * 60;
 
   const totalMilliseconds = getMsRemaining(dueTime);
-  const days: number = +Math.floor(totalMilliseconds / msOnADay);
+  const days: number = +Math.floor(totalMilliseconds / MS_PER_DAY);
   const hours: number = +Math.floor(
-    (totalMilliseconds - days * msOnADay) / msOnAnHour
+    (totalMilliseconds - days * MS_PER_DAY) / MS_PER_HOUR
   );
   const minutes: number = +Math.floor(
-    (totalMilliseconds - (days * msOnADay + hours * msOnAnHour)) / msOnAnMinute
+    (totalMilliseconds - (days * MS_PER_DAY + hours * MS_PER_HOUR)) / MS_PER_MINUTE
   );
 
   return [

--- a/src/components/timeRemaining/timeRemaining.stories.mdx
+++ b/src/components/timeRemaining/timeRemaining.stories.mdx
@@ -10,7 +10,7 @@ TimeRemaining component.
 <Props of={TimeRemaining} />
 
 export const Template = (args) => (
-  <TimeRemaining dueTime={args.dueTime} />
+  <TimeRemaining dueTime={args.dueTime} simpleDisplay={args.simpleDisplay}/>
 );
 
 ## Basic
@@ -23,6 +23,7 @@ export const Template = (args) => (
     }}
     args={{
       dueTime: new Date('2023-06-27'),
+      simpleDisplay: true
     }}
   >
     {Template.bind({})}


### PR DESCRIPTION
mejorado el reloj:
- Ahora incluye un parámetro opcional (simpleDisplay) para marcar que solo ponga una unidad de tiempo ("8h" en vez de "8h y 34 min")
- No se muestran los valores que valgan 0 ("4h" en vez de "0d 4h")