### PR TITLE
Local files from lib now exportable

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "sass": "1.59.3",
     "typescript": "4.6.3",
     "universal-cookie": "4.0.4",
-    "web-vitals": "2.1.4",
-    "usehooks-ts" : "2.1.1"
+    "usehooks-ts": "2.1.1",
+    "web-vitals": "2.1.4"
   },
   "peerDependencies": {
-    "react":"18.2.0"
+    "react": "18.2.0"
   },
   "scripts": {
     "build": "rimraf dist && rollup -c",
@@ -85,11 +85,12 @@
     "@storybook/testing-library": "0.0.13",
     "babel-plugin-named-exports-order": "0.0.2",
     "prop-types": "15.8.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "rollup": "3.19.1",
+    "rollup-plugin-copy": "3.4.0",
     "rollup-plugin-dts": "5.2.0",
     "rollup-plugin-scss": "3",
-    "webpack": "5.76.1",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "webpack": "5.76.1"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,38 +1,44 @@
-const resolve = require("@rollup/plugin-node-resolve");
-const commonjs = require("@rollup/plugin-commonjs");
-const typescript = require("@rollup/plugin-typescript");
-const dts = require("rollup-plugin-dts").default;
-const scss = require("rollup-plugin-scss");
+const resolve = require('@rollup/plugin-node-resolve');
+const commonjs = require('@rollup/plugin-commonjs');
+const typescript = require('@rollup/plugin-typescript');
+const dts = require('rollup-plugin-dts').default;
+const scss = require('rollup-plugin-scss');
+const copy = require('rollup-plugin-copy');
 
-const packageJson = require("./package.json");
+const packageJson = require('./package.json');
 
 module.exports = [
   {
-    input: "src/index.ts",
+    input: 'src/index.ts',
     output: [
       {
         file: packageJson.main,
-        format: "cjs",
+        format: 'cjs',
         sourcemap: true,
       },
       {
         file: packageJson.module,
-        format: "esm",
+        format: 'esm',
         sourcemap: true,
       },
     ],
     plugins: [
       resolve(),
       commonjs(),
-      typescript({ tsconfig: "./tsconfig.json" }),
-      scss()
+      typescript({ tsconfig: './tsconfig.json' }),
+      scss(),
+      copy({
+        targets: [
+          { src: 'src/components/style/fonts', dest: 'dist/cjs' },
+        ],
+      }),
     ],
-    external: ["react", "react-dom"]
+    external: ['react', 'react-dom'],
   },
   {
-    input: "dist/esm/types/index.d.ts",
-    output: [{ file: "dist/index.d.ts", format: "esm" }],
-    external: [/\.scss$/, "react", "react-dom"],
+    input: 'dist/esm/types/index.d.ts',
+    output: [{ file: 'dist/index.d.ts', format: 'esm' }],
+    external: [/\.scss$/, 'react', 'react-dom'],
     plugins: [dts()],
   },
 ];


### PR DESCRIPTION
Fonts now working thanks to **rollup-plugin-copy**

If you want to copy something just set the source (src) and the destination (dest) on rollup.config.js:
![image](https://user-images.githubusercontent.com/28260713/227161452-dabecc3b-34eb-44fc-bded-f1a90dad9546.png)
